### PR TITLE
updated fontend UI of listings page

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -1,5 +1,52 @@
+.card-container {
+  width: 250px;
+  border: 1px solid rgba(230,230,230,0.9);
+  border-radius: 5px;
+  padding-bottom: 20px;
+  background-color: white;
+}
+
+.card-container:hover {
+  opacity: 0.4;
+}
+
 .card-img-top {
-  height: 100px;
-  width: auto;
+  height: 250px;
   object-fit: cover;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+}
+
+.card-body {
+  width: 250px;
+  position: relative;
+  margin-bottom: 10px;
+}
+
+.card-info {
+  position: absolute;
+  left: 10px;
+}
+
+.card-info h5 {
+  font-size: 14px;
+  font-weight: bold;
+  color: black;
+}
+
+.card-info p {
+  font-size: 12px;
+  color: black;
+  font-weight: lighter;
+}
+
+.card-price {
+  position: absolute;
+  right: 10px;
+}
+
+.card-price h2 {
+  font-size: 14px;
+  color: black;
+  margin-top: 10px;
 }

--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -26,12 +26,18 @@
 .card-info {
   position: absolute;
   left: 10px;
+  width: 55%;
 }
 
 .card-info h5 {
   font-size: 14px;
   font-weight: bold;
   color: black;
+
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+
 }
 
 .card-info p {

--- a/app/views/listings/_listing.html.erb
+++ b/app/views/listings/_listing.html.erb
@@ -4,11 +4,11 @@
       <img class="card-img-top" src="https://images.unsplash.com/photo-1502005229762-cf1b2da7c5d6?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2787&q=80" alt="Card image cap">
       <div class="card-body">
         <div class="card-info">
-            <h5><%= listing.name %></h5>
-            <p>Guests: <%= listing.capacity %></p>
+            <h5><%= listing.address %></h5>
+            <p class="text-secondary">Guests: <%= listing.capacity %></p>
         </div>
         <div class="card-price">
-            <h2>S$<%= listing.rate_per_day %>/day</h2>
+            <h2 class="text-secondary">S$<%= listing.rate_per_day %>/day</h2>
         </div>
         </div>
     </div>

--- a/app/views/listings/_listing.html.erb
+++ b/app/views/listings/_listing.html.erb
@@ -1,14 +1,14 @@
-<div class="col-sm-3 my-2">
+<div class="col-xs-12 col-sm-6 col-md-6 col-lg-4 col-xl-3 my-2">
   <%= link_to listing_path(listing), data: { turbolinks: false }, class: 'text-decoration-none' do %>
-    <div class="card h-100">
+    <div class="card-container">
       <img class="card-img-top" src="https://images.unsplash.com/photo-1502005229762-cf1b2da7c5d6?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2787&q=80" alt="Card image cap">
       <div class="card-body">
         <div class="card-info">
-            <h5 class="card-title text-dark"><%= listing.name %></h5>
-            <p class="card-text text-secondary">Guests: <%= listing.capacity %></p>
+            <h5><%= listing.name %></h5>
+            <p>Guests: <%= listing.capacity %></p>
         </div>
         <div class="card-price">
-            <p class="card-text text-secondary">S$<%= listing.rate_per_day %>/day</p>
+            <h2>S$<%= listing.rate_per_day %>/day</h2>
         </div>
         </div>
     </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -15,7 +15,7 @@
           <%= link_to "Home", listings_path(), class: "nav-link" %>
         </li>
         <li class="nav-item">
-          <%= link_to "Messages", "#", class: "nav-link" %>
+          <%= link_to "Add Listing", new_listing_path(), class: "nav-link" %>
         </li>
         <li class="nav-item dropdown">
           <% if current_user.photo.key %>
@@ -26,7 +26,6 @@
 
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
             <%= link_to "Profile", user_path(current_user), class: "dropdown-item" %>
-            <%= link_to "Add Listing", new_listing_path(), class: "dropdown-item" %>
             <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
           </div>
         </li>


### PR DESCRIPTION
listings page
- made card grid responsiveness for all device types
- layout of card content (left side: listing name + no. of guest; right side: price/night)
- added 0.4 opacity to card when hover over it

Navbar
- moved "add listing" to nav-link for better UX 
