### PR TITLE
Change booking model attr

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -4,7 +4,9 @@ class Booking < ApplicationRecord
   belongs_to :listing
   has_one :review
 
+  # Validations
   validates :start_date, :end_date, presence: true
+  validates :booking_status, inclusion: { in: ["pending", "confirmed", "rejected"] }
   validate :end_date_after_start_date
 
   private

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -6,7 +6,7 @@ class Booking < ApplicationRecord
 
   # Validations
   validates :start_date, :end_date, presence: true
-  validates :booking_status, inclusion: { in: ["pending", "confirmed", "rejected"] }
+  validates :booking_status, inclusion: { in: ["PENDING", "CONFIRMED", "COMPLETED", "CANCELLED"] }
   validate :end_date_after_start_date
 
   private

--- a/db/migrate/20211205035134_change_dates_to_bookings.rb
+++ b/db/migrate/20211205035134_change_dates_to_bookings.rb
@@ -1,0 +1,7 @@
+class ChangeDatesToBookings < ActiveRecord::Migration[6.1]
+  def change
+    change_column :bookings, :start_date, :date
+    change_column :bookings, :end_date, :date
+  end
+  end
+end

--- a/db/migrate/20211205035134_change_dates_to_bookings.rb
+++ b/db/migrate/20211205035134_change_dates_to_bookings.rb
@@ -1,7 +1,0 @@
-class ChangeDatesToBookings < ActiveRecord::Migration[6.1]
-  def change
-    change_column :bookings, :start_date, :date
-    change_column :bookings, :end_date, :date
-  end
-  end
-end

--- a/db/migrate/20211206120620_rename_old_date_attrs.rb
+++ b/db/migrate/20211206120620_rename_old_date_attrs.rb
@@ -1,0 +1,6 @@
+class RenameOldDateAttrs < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :bookings, :start_date, :old_start_date
+    rename_column :bookings, :end_date, :old_end_date
+  end
+end

--- a/db/migrate/20211206121052_add_start_date_end_date_to_bookings.rb
+++ b/db/migrate/20211206121052_add_start_date_end_date_to_bookings.rb
@@ -1,0 +1,6 @@
+class AddStartDateEndDateToBookings < ActiveRecord::Migration[6.1]
+  def change
+      add_column :bookings, :start_date, :date
+      add_column :bookings, :end_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_04_064111) do
+ActiveRecord::Schema.define(version: 2021_12_06_121052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,8 +44,8 @@ ActiveRecord::Schema.define(version: 2021_12_04_064111) do
   end
 
   create_table "bookings", force: :cascade do |t|
-    t.integer "start_date"
-    t.integer "end_date"
+    t.integer "old_start_date"
+    t.integer "old_end_date"
     t.string "booking_status", default: "PENDING"
     t.bigint "user_id", null: false
     t.bigint "listing_id", null: false
@@ -53,6 +53,8 @@ ActiveRecord::Schema.define(version: 2021_12_04_064111) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "guests", default: 1
     t.float "cost"
+    t.date "start_date"
+    t.date "end_date"
     t.index ["listing_id"], name: "index_bookings_on_listing_id"
     t.index ["user_id"], name: "index_bookings_on_user_id"
   end


### PR DESCRIPTION
Bookings tables was created with start_date and end_date columns of type "integer"
This needs to be changed to type "date"

1. Created migrations to change start_date, end_date in Bookings to old_start_date and old_end_date
![image](https://user-images.githubusercontent.com/86636163/144845122-f83c5376-968f-4c5f-9366-c0377132e98f.png)

2. Created migrations to add 2 columns start_date, end_date of type "date"
![image](https://user-images.githubusercontent.com/86636163/144845255-524b8947-a23f-4c79-9369-a0fc96280712.png)

3. Migration works, double checked column names and type.
![image](https://user-images.githubusercontent.com/86636163/144845346-fbdde9d5-6ec6-4640-a3c6-4ba308cea57a.png)

4. Added validation for booking_status
![image](https://user-images.githubusercontent.com/86636163/144845444-4709f4d7-0858-4b40-bd96-790c7cfcd70c.png)

